### PR TITLE
Correção da linha 12, variável imutável sendo tratada como mutável

### DIFF
--- a/exs/mundo_1/rust/018.rs
+++ b/exs/mundo_1/rust/018.rs
@@ -12,7 +12,7 @@ fn main() {
 
     std::io::stdin().read_line(&mut angulo).unwrap();
 
-    let angulo: f32 = angulo
+    let mut angulo: f32 = angulo
         .trim()
         .parse()
         .expect("Valor do ângulo não é um número");


### PR DESCRIPTION
O código não era executável já que uma variável imutável estava sendo modificada na linha 20. 